### PR TITLE
Fixes periodic -inf log det Jacobians in Tanh.foward()

### DIFF
--- a/survae/transforms/bijections/elementwise_nonlinear.py
+++ b/survae/transforms/bijections/elementwise_nonlinear.py
@@ -56,8 +56,10 @@ class SneakyReLU(Bijection):
 
 class Tanh(Bijection):
     def forward(self, x):
+        # The "+ 1e-45" bit is for numerical stability. Otherwise the ldj will be -inf where any element of x is around
+        # 6.0 or greater, since torch.tanh() returns 1.0 around that point. This way it maxes out around -103.2789.
         z = torch.tanh(x)
-        ldj = torch.log(1 - z ** 2)
+        ldj = torch.log(1 - z ** 2 + 1e-45)
         ldj = sum_except_batch(ldj)
         return z, ldj
 


### PR DESCRIPTION
Currently, the Tanh() bijection returns -inf as the log Jacobian determinant whenever any of the elements of the input tensor are roughly 6.0 or greater. This is because torch.tanh() returns exactly 1.0 at that point, causing the current implementation to pass 1 - 1 ** 2 = 0 to torch.log(), which of course returns -inf. This PR fixes the problem by adding a very small constant (1e-45) to the input to torch.log().